### PR TITLE
Fix markdown copy

### DIFF
--- a/content.js
+++ b/content.js
@@ -191,8 +191,9 @@ console.log('copy-article content.js injected');
       item['text/html'] = new Blob([fullHtml], {type: 'text/html'});
       item['text/plain'] = new Blob([textContent], {type: 'text/plain'});
     } else if (format === 'markdown') {
+      // Some browsers reject unsupported MIME types like text/markdown.
+      // Use plain text only for wider compatibility.
       item['text/plain'] = new Blob([markdown], {type: 'text/plain'});
-      item['text/markdown'] = new Blob([markdown], {type: 'text/markdown'});
     } else {
       item['text/plain'] = new Blob([textContent], {type: 'text/plain'});
     }


### PR DESCRIPTION
## Summary
- fix markdown copy failure by using plain text only

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3af00f08322b78c2dd6f75988cb